### PR TITLE
Fixing value parsing bug

### DIFF
--- a/src/Services/RemoteWeb.php
+++ b/src/Services/RemoteWeb.php
@@ -119,7 +119,7 @@ class RemoteWeb extends BaseRestService implements CachedInterface
         } else {
             Session::replaceLookups($value, true);
             $part = urlencode($name);
-            if (!empty($value)) {
+            if (!empty($value) || is_numeric($value)) {
                 $part .= '=' . urlencode($value);
             }
             if ($add_to_query) {


### PR DESCRIPTION
hi,
I have a remote web service that must be call in following way:
http://###.com/messages?offset=0&limit=100

because `parseArrayParameter` use `empty()` function for testing, the value of `offset` is considered to be empty, and real web service is called without `offset`, that is wrong in my case..