### PR TITLE
Fixed query params, when passing string with '=' sign as qs parameter…

### DIFF
--- a/src/Services/RemoteWeb.php
+++ b/src/Services/RemoteWeb.php
@@ -196,7 +196,7 @@ class RemoteWeb extends BaseRestService
 
         // inbound parameters from request to be passed on
         foreach ($requestQuery as $q) {
-            $pairs = explode('=', $q);
+            $pairs = explode('=', $q, 2);
             $name = trim(array_get($pairs, 0));
             $value = trim(array_get($pairs, 1));
             $outbound = true;


### PR DESCRIPTION
…. https://github.com/dreamfactorysoftware/dreamfactory/issues/185
We can solve this issue just by adding additional parameter to explode function that limits resulting array length and doesn't allow to devide array into more than two pices